### PR TITLE
fix invalid field error message

### DIFF
--- a/jsonapi/unmarshal.go
+++ b/jsonapi/unmarshal.go
@@ -260,7 +260,7 @@ func UnmarshalInto(input map[string]interface{}, targetStructType reflect.Type, 
 						}
 
 						if !field.IsValid() {
-							return errors.New("expected struct " + targetStructType.Name() + " to have field " + fieldName)
+							return errors.New("did not expect struct " + targetStructType.Name() + " to have field " + fieldName)
 						}
 					}
 


### PR DESCRIPTION
Fixed the error message to tell the user that the invalid field was not expected for the given struct. 
